### PR TITLE
Fix timeout issue when calling RestoreSqlBackup

### DIFF
--- a/src/Cake.SqlServer/Backup/SqlBackupsImpl.cs
+++ b/src/Cake.SqlServer/Backup/SqlBackupsImpl.cs
@@ -53,7 +53,7 @@ end
 
                 context.Log.Debug($"Executing SQL : {sql}");
 
-                var command = new SqlCommand(sql, connection);
+                var command = SqlServerAliasesImpl.CreateSqlCommand(sql, connection);
                 command.Parameters.AddWithValue("@backupFile", backupFile.ToString());
                 for (var i = 0; i < logicalNames.Count; i++)
                 {


### PR DESCRIPTION
Replace "new SqlCommand" with call to CreateSqlCommand in RestoreSqlBackup so CommandTimeout will be applied.