### PR TITLE
Cake 0.33

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Allows you to use the same connection for multiple SQL commands. Close the conne
 Example:
 
 ```c#
-using (var connection = OpenSqlConnection(@"Data Source=(LocalDb)\v12.0;Initial Catalog=MyDatabase"))
+using (var connection = OpenSqlConnection(@"Data Source=(localdb)\MSSqlLocalDb;Initial Catalog=MyDatabase"))
 {
     ExecuteSqlCommand(connection, "...");
     ExecuteSqlFile(connection, "./somePath/MyScript.sql");
@@ -117,7 +117,7 @@ Allows you to specify the command timeout in seconds for all commands. This is u
 
 ```c#
 SetSqlCommandTimeout(60);
-using (var connection = OpenSqlConnection(@"Data Source=(LocalDb)\v12.0;Initial Catalog=MyDatabase"))
+using (var connection = OpenSqlConnection(@"Data Source=(localdb)\MSSqlLocalDb;Initial Catalog=MyDatabase"))
 {
     ExecuteSqlCommand(connection, "..."); // <- execute long-running command
 }
@@ -140,7 +140,7 @@ Example:
 ```c#
 Task("Restore-Database")
 	.Does(() => {
-		var connString = @"data source=(LocalDb)\v12.0";
+		var connString = @"data source=(localdb)\MSSqlLocalDb";
 
 		var backupFilePath = new FilePath(@".\src\Tests\multiFileBackup.bak");
 		backupFilePath = backupFilePath.MakeAbsolute(Context.Environment);
@@ -166,7 +166,7 @@ Example:
 Task("Backup-Database")
     .Does(() =>
     {
-        var connString = @"data source=(LocalDb)\v12.0";
+        var connString = @"data source=(localdb)\MSSqlLocalDb";
         var databaseName = "MyDatabase";
         BackupDatabase(connString, databaseName, new BackupDatabaseSettings() 
            {
@@ -188,7 +188,7 @@ To create a bacpac file from a database call:
 ```c#
 Task("Create-Bacpac")
 	.Does(() =>{
-		var connString = @"data source=(LocalDb)\v12.0";
+		var connString = @"data source=(localdb)\MSSqlLocalDb";
 
 		var dbName = "ForBacpac";
 
@@ -203,7 +203,7 @@ To restore from bacpac file into a database use this:
 ```c#
 Task("Restore-From-Bacpac")
 	.Does(() =>{
-		var connString = @"data source=(LocalDb)\v12.0";
+		var connString = @"data source=(localdb)\MSSqlLocalDb";
 
 		var dbName = "FromBacpac";
 
@@ -220,7 +220,7 @@ To extract a dacpac file from a database call:
 ```c#
 Task("Extract-Dacpac")
 	.Does(() =>{
-		var connString = @"data source=(LocalDb)\v12.0";
+		var connString = @"data source=(localdb)\MSSqlLocalDb";
      
 		var dbName = "ForDacpac";
      
@@ -240,7 +240,7 @@ To publish from dacpac file into a database use this:
 ```c#
 Task("Create-Bacpac")
 	.Does(() =>{
-		var connString = @"data source=(LocalDb)\v12.0";
+		var connString = @"data source=(localdb)\MSSqlLocalDb";
 
 		var dbName = "ForDacpac";
 
@@ -300,9 +300,9 @@ You can also check our [integration tests](https://github.com/AMVSoftware/Cake.S
 
 ### Gotchas
 
-Remember to always add `@` before your connection strings. Some connection strings (i.e. `(localdb)\v12.0`) can contain backward slash `\` and that is an escape symbol in C#. So you need to always add `@` before the string:
+Remember to always add `@` before your connection strings. Some connection strings (i.e. `(localdb)\MSSqlLocalDb`) can contain backward slash `\` and that is an escape symbol in C#. So you need to always add `@` before the string:
 
-	var connString = @"(localDb)\v12.0";
+	var connString = @"(localdb)\MSSqlLocalDb";
 
 `\v` is the C# escape sequence for vertical tab which is not what you want. Using the verbatim string syntax `@` prevents escape sequences from being interpreted and you get what you expect, verbatim `\` and `v` characters.
 

--- a/src/Cake.SqlServer/Backup/BackupAliases.cs
+++ b/src/Cake.SqlServer/Backup/BackupAliases.cs
@@ -26,7 +26,7 @@ namespace Cake.SqlServer
         ///     Task("Restore-Database")
         ///         .Does(() =>
         ///         {
-        ///             var connString = @"data source=(LocalDb)\v12.0";
+        ///             var connString = @"data source=(localdb)\MSSqlLocalDb";
         ///             var backupFile = new FilePath("C:/tmp/myBackup.bak");
         ///             RestoreSqlBackup(connString, backupFile, new RestoreSqlBackupSettings() 
         ///                {
@@ -60,7 +60,7 @@ namespace Cake.SqlServer
         ///     Task("Restore-Database")
         ///         .Does(() =>
         ///         {
-        ///             var connString = @"data source=(LocalDb)\v12.0";
+        ///             var connString = @"data source=(localdb)\MSSqlLocalDb";
         ///             var backupFile = new FilePath("C:/tmp/myBackup.bak");
         ///             RestoreSqlBackup(connString, backupFile); 
         ///         });
@@ -86,7 +86,7 @@ namespace Cake.SqlServer
         ///     Task("Backup-Database")
         ///         .Does(() =>
         ///         {
-        ///             var connString = @"data source=(LocalDb)\v12.0";
+        ///             var connString = @"data source=(localdb)\MSSqlLocalDb";
         ///             var databaseName = "MyDatabase";
         ///             BackupDatabase(connString, databaseName, new BackupDatabaseSettings() 
         ///                {

--- a/src/Cake.SqlServer/Cake.SqlServer.csproj
+++ b/src/Cake.SqlServer/Cake.SqlServer.csproj
@@ -35,8 +35,8 @@
     <DocumentationFile>bin\Release\Cake.SqlServer.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.30.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.30.0\lib\net46\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.33.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.33.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Tools.Schema.Sql, Version=13.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.130.3485.1\lib\net40\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>

--- a/src/Cake.SqlServer/Dac/DacAliases.cs
+++ b/src/Cake.SqlServer/Dac/DacAliases.cs
@@ -25,7 +25,7 @@ namespace Cake.SqlServer
         /// 
         ///     Task("Create-Bacpac")
         ///     	.Does(() =>{
-        ///     		var connString = @"data source=(LocalDb)\v12.0";
+        ///     		var connString = @"data source=(localdb)\MSSqlLocalDb";
         ///     
         ///     		var dbName = "ForBacpac";
         ///     
@@ -63,7 +63,7 @@ namespace Cake.SqlServer
         /// 
         ///     Task("Create-Bacpac")
         ///     	.Does(() =>{
-        ///     		var connString = @"data source=(LocalDb)\v12.0";
+        ///     		var connString = @"data source=(localdb)\MSSqlLocalDb";
         ///     
         ///     		var dbName = "FromBacpac";
         ///     
@@ -98,7 +98,7 @@ namespace Cake.SqlServer
         /// 
         ///     Task("Extract-Dacpac")
         ///     	.Does(() =>{
-        ///     		var connString = @"data source=(LocalDb)\v12.0";
+        ///     		var connString = @"data source=(localdb)\MSSqlLocalDb";
         ///     
         ///     		var dbName = "ForDacpac";
         ///     
@@ -139,7 +139,7 @@ namespace Cake.SqlServer
         /// 
         ///     Task("Create-Bacpac")
         ///     	.Does(() =>{
-        ///     		var connString = @"data source=(LocalDb)\v12.0";
+        ///     		var connString = @"data source=(localdb)\MSSqlLocalDb";
         ///     
         ///     		var dbName = "ForDacpac";
         ///     

--- a/src/Cake.SqlServer/SqlServerAliases.cs
+++ b/src/Cake.SqlServer/SqlServerAliases.cs
@@ -37,7 +37,7 @@ namespace Cake.SqlServer
         ///     Task("Deploy-Database")
         ///          .Does(() =>
         ///          {
-        ///             var connectionString = @"Server=(LocalDb)\v12.0";
+        ///             var connectionString = @"Server=(localdb)\MSSqlLocalDb";
         ///             var dbName = "CakeTest";
         /// 
         ///             if (DatabaseExists(connectionString, dbName))
@@ -73,7 +73,7 @@ namespace Cake.SqlServer
         ///     Task("Drop-Database")
         ///          .Does(() =>
         ///          {
-        ///             var connectionString = @"Server=(LocalDb)\v12.0";
+        ///             var connectionString = @"Server=(localdb)\MSSqlLocalDb";
         ///             var dbName = "CakeTest";
         ///             DropDatabase(connectionString, dbName);
         ///         });
@@ -105,7 +105,7 @@ namespace Cake.SqlServer
         ///     Task("Create-Database")
         ///          .Does(() =>
         ///          {
-        ///             var connectionString = @"Server=(LocalDb)\v12.0";
+        ///             var connectionString = @"Server=(localdb)\MSSqlLocalDb";
         ///             var dbName = "CakeTest";
         ///             CreateDatabase(connectionString, dbName);
         ///         });
@@ -137,7 +137,7 @@ namespace Cake.SqlServer
         ///     Task("Create-Database")
         ///          .Does(() =>
         ///          {
-        ///             var connectionString = @"Server=(LocalDb)\v12.0";
+        ///             var connectionString = @"Server=(localdb)\MSSqlLocalDb";
         ///             var dbName = "CakeTest";
         ///             var createSettings = new CreateDatabaseSettings()
         ///                                          .WithPrimaryFile(@"C:\MyPath\DB\CakeTest.mdf")
@@ -171,7 +171,7 @@ namespace Cake.SqlServer
         ///     Task("Create-Database-If-Not-Exists")
         ///          .Does(() =>
         ///          {
-        ///             var connectionString = @"Server=(LocalDb)\v12.0";
+        ///             var connectionString = @"Server=(localdb)\MSSqlLocalDb";
         ///             var dbName = "CakeTest";
         ///             CreateDatabaseIfNotExists(connectionString, dbName);
         ///         });
@@ -201,7 +201,7 @@ namespace Cake.SqlServer
         ///     Task("Create-Database-If-Not-Exists")
         ///          .Does(() =>
         ///          {
-        ///             var connectionString = @"Server=(LocalDb)\v12.0";
+        ///             var connectionString = @"Server=(localdb)\MSSqlLocalDb";
         ///             var dbName = "CakeTest";
         ///             var createSettings = new CreateDatabaseSettings()
         ///                                          .WithPrimaryFile(@"C:\MyPath\DB\CakeTest.mdf")
@@ -234,7 +234,7 @@ namespace Cake.SqlServer
         ///     Task("ReCreate-Database")
         ///          .Does(() =>
         ///          {
-        ///             var connectionString = @"Server=(LocalDb)\v12.0";
+        ///             var connectionString = @"Server=(localdb)\MSSqlLocalDb";
         ///             var dbName = "CakeTest";
         ///             var createSettings = new CreateDatabaseSettings()
         ///                                          .WithPrimaryFile(@"C:\MyPath\DB\CakeTest.mdf")
@@ -269,7 +269,7 @@ namespace Cake.SqlServer
         ///     Task("ReCreate-Database")
         ///          .Does(() =>
         ///          {
-        ///             var connectionString = @"Server=(LocalDb)\v12.0";
+        ///             var connectionString = @"Server=(localdb)\MSSqlLocalDb";
         ///             var dbName = "CakeTest";
         ///             var createSettings = new CreateDatabaseSettings()
         ///                                          .WithPrimaryFile(@"C:\MyPath\DB\CakeTest.mdf")
@@ -304,7 +304,7 @@ namespace Cake.SqlServer
         ///     Task("Sql-Operations")
         ///         .Does(() =>
         ///         {
-        ///             var connectionString = @"Data Source=(LocalDb)\v12.0;Initial Catalog=MyDatabase";
+        ///             var connectionString = @"Data Source=(localdb)\MSSqlLocalDb;Initial Catalog=MyDatabase";
         ///             var sqlCommand = "create table [CakeTest].dbo.[CakeTestTable] (id int null)";
         ///             ExecuteSqlCommand(connectionString, sqlCommand);
         ///         });
@@ -334,7 +334,7 @@ namespace Cake.SqlServer
         ///     Task("Sql-Operations")
         ///         .Does(() =>
         ///         {
-        ///             using (var connection = OpenSqlConnection(@"Data Source=(LocalDb)\v12.0;Initial Catalog=MyDatabase"))
+        ///             using (var connection = OpenSqlConnection(@"Data Source=(localdb)\MSSqlLocalDb;Initial Catalog=MyDatabase"))
         ///             {
         ///                 ExecuteSqlCommand(connection, "create table [CakeTest].dbo.[CakeTestTable] (id int null)");
         ///                 ExecuteSqlCommand(connection, "...");
@@ -366,7 +366,7 @@ namespace Cake.SqlServer
         ///     Task("Sql-Operations")
         ///         .Does(() =>
         ///         {
-        ///             var connectionString = @"Data Source=(LocalDb)\v12.0;Initial Catalog=MyDatabase";
+        ///             var connectionString = @"Data Source=(localdb)\MSSqlLocalDb;Initial Catalog=MyDatabase";
         ///             var sqlFile = "./somePath/MyScript.sql";
         ///             ExecuteSqlCommand(connectionString, sqlFile);
         ///         });
@@ -396,7 +396,7 @@ namespace Cake.SqlServer
         ///     Task("Sql-Operations")
         ///         .Does(() =>
         ///         {
-        ///             using (var connection = OpenSqlConnection(@"Data Source=(LocalDb)\v12.0;Initial Catalog=MyDatabase"))
+        ///             using (var connection = OpenSqlConnection(@"Data Source=(localdb)\MSSqlLocalDb;Initial Catalog=MyDatabase"))
         ///             {
         ///                 ExecuteSqlFile(connection, "./somePath/MyScript.sql");
         ///                 ExecuteSqlFile(connection, "./somePath/MyOtherScript.sql");
@@ -427,7 +427,7 @@ namespace Cake.SqlServer
         ///     Task("Sql-Operations")
         ///         .Does(() =>
         ///         {
-        ///             using (var connection = OpenSqlConnection(@"Data Source=(LocalDb)\v12.0;Initial Catalog=MyDatabase"))
+        ///             using (var connection = OpenSqlConnection(@"Data Source=(localdb)\MSSqlLocalDb;Initial Catalog=MyDatabase"))
         ///             {
         ///                 ExecuteSqlCommand(connection, "...");
         ///                 ExecuteSqlFile(connection, "./somePath/MyScript.sql");
@@ -458,7 +458,7 @@ namespace Cake.SqlServer
         ///         .Does(() =>
         ///         {
         ///             SetSqlCommandTimeout(60);
-        ///             using (var connection = OpenSqlConnection(@"Data Source=(LocalDb)\v12.0;Initial Catalog=MyDatabase"))
+        ///             using (var connection = OpenSqlConnection(@"Data Source=(localdb)\MSSqlLocalDb;Initial Catalog=MyDatabase"))
         ///             {
         ///                 ExecuteSqlCommand(connection, "...");
         ///                 ExecuteSqlFile(connection, "./somePath/MyScript.sql");

--- a/src/Cake.SqlServer/packages.config
+++ b/src/Cake.SqlServer/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.30.0" targetFramework="net472" />
+  <package id="Cake.Core" version="0.33.0" targetFramework="net472" />
   <package id="Microsoft.SqlServer.DacFx.x64" version="130.3485.1" targetFramework="net472" />
 </packages>

--- a/src/Tests/RestoreDatabaseTests.cs
+++ b/src/Tests/RestoreDatabaseTests.cs
@@ -13,7 +13,7 @@ namespace Tests
 {
     public class RestoreDatabaseTests
     {
-        private const String ConnectionString = @"data source=(LocalDb)\v12.0";
+        private const String ConnectionString = @"data source=(localdb)\MSSqlLocalDb";
         private readonly ICakeContext context;
 
         public RestoreDatabaseTests()

--- a/src/Tests/SqlBacpacImplTests.cs
+++ b/src/Tests/SqlBacpacImplTests.cs
@@ -12,7 +12,7 @@ namespace Tests
 {
     public class SqlBacpacImplTests
     {
-        private const String ConnectionString = @"data source=(LocalDb)\v12.0";
+        private const String ConnectionString = @"data source=(localdb)\MSSqlLocalDb";
         private readonly ICakeContext context;
 
 

--- a/src/Tests/SqlDacpacImplTests.cs
+++ b/src/Tests/SqlDacpacImplTests.cs
@@ -12,7 +12,7 @@ namespace Tests
 {
     public class SqlDacpacImplTests
     {
-        private const String ConnectionString = @"data source=(LocalDb)\v12.0";
+        private const String ConnectionString = @"data source=(localdb)\MSSqlLocalDb";
         private readonly ICakeContext context;
 
 

--- a/src/Tests/SqlServerAliasesTests.cs
+++ b/src/Tests/SqlServerAliasesTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Data.SqlClient;
 using System.IO;
@@ -14,7 +14,7 @@ namespace Tests
 {
     public class SqlServerAliasesTests : IDisposable
     {
-        private const String ConnectionString = @"data source=(LocalDb)\v12.0";
+        private const String ConnectionString = @"data source=(localdb)\MSSqlLocalDb";
         private readonly ICakeContext context;
 
         public SqlServerAliasesTests()
@@ -236,7 +236,7 @@ namespace Tests
         public void ExecuteSqlFile_Executes_Successfuly()
         {
             //Arrange
-            var connectionString = @"data source=(LocalDb)\v12.0;Database=ForFileExecution";
+            var connectionString = @"data source=(localdb)\MSSqlLocalDb;Database=ForFileExecution";
             var dbName = "ForFileExecution";
             var tableName1 = "WillExist1";
             var tableName2 = "WillExist2";
@@ -260,7 +260,7 @@ namespace Tests
         [Test]
         public void Trying_To_Connect_WithBadConnString_ThowsMeaningful_Exception()
         {
-            var connString = "data source=(LocalDb)\v12.0";
+            var connString = "data source=(localdb)\v12.0";
             Action act = () => SqlServerAliases.CreateDatabaseIfNotExists(context, connString, "ShouldThrow");
 
             act.Should().Throw<Exception>()

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
-  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <Import Project="D:\trailmax\Projects\Cake.SqlServer\src\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('D:\trailmax\Projects\Cake.SqlServer\src\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -38,20 +38,20 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.30.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.30.0\lib\net46\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.33.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.33.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Cake.Testing, Version=0.30.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Testing.0.30.0\lib\net46\Cake.Testing.dll</HintPath>
+    <Reference Include="Cake.Testing, Version=0.33.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Testing.0.33.0\lib\net46\Cake.Testing.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Dapper, Version=1.50.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Dapper.1.50.5\lib\net451\Dapper.dll</HintPath>
+    <Reference Include="Dapper, Version=1.60.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Dapper.1.60.6\lib\net451\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions, Version=5.4.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.5.4.1\lib\net47\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=5.6.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.5.6.0\lib\net47\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Tools.Schema.Sql, Version=13.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.130.3485.1\lib\net40\Microsoft.Data.Tools.Schema.Sql.dll</HintPath>
@@ -71,20 +71,20 @@
     <Reference Include="Microsoft.SqlServer.Types, Version=13.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.DacFx.x64.130.3485.1\lib\net40\Microsoft.SqlServer.Types.dll</HintPath>
     </Reference>
-    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\packages\NSubstitute.3.1.0\lib\net46\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.4.0.0\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.1\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -141,8 +141,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
-    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Tests/packages.config
+++ b/src/Tests/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.30.0" targetFramework="net472" />
-  <package id="Cake.Testing" version="0.30.0" targetFramework="net472" />
-  <package id="Castle.Core" version="4.3.1" targetFramework="net472" />
-  <package id="Dapper" version="1.50.5" targetFramework="net47" />
-  <package id="FluentAssertions" version="5.4.1" targetFramework="net472" />
+  <package id="Cake.Core" version="0.33.0" targetFramework="net472" />
+  <package id="Cake.Testing" version="0.33.0" targetFramework="net472" />
+  <package id="Castle.Core" version="4.4.0" targetFramework="net472" />
+  <package id="Dapper" version="1.60.6" targetFramework="net472" />
+  <package id="FluentAssertions" version="5.6.0" targetFramework="net472" />
   <package id="Microsoft.SqlServer.DacFx.x64" version="130.3485.1" targetFramework="net472" />
-  <package id="NSubstitute" version="3.1.0" targetFramework="net47" />
-  <package id="NUnit" version="3.10.1" targetFramework="net47" />
-  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net47" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net472" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net472" />
+  <package id="NSubstitute" version="4.0.0" targetFramework="net472" />
+  <package id="NUnit" version="3.11.0" targetFramework="net472" />
+  <package id="NUnit3TestAdapter" version="3.13.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net472" />
 </packages>

--- a/tests.cake
+++ b/tests.cake
@@ -56,8 +56,8 @@ Task("Debug")
 Task("Database-Operations")
     .Does(() => 
     {
-        var masterConnectionString = @"data source=(LocalDb)\v12.0;";
-        var connectionString = @"data source=(LocalDb)\v12.0;Database=OpsCakeTest";
+        var masterConnectionString = @"data source=(localdb)\MSSqlLocalDb;";
+        var connectionString = @"data source=(localdb)\MSSqlLocalDb;Database=OpsCakeTest";
 
         var dbName = "OpsCakeTest";
 
@@ -87,7 +87,7 @@ Task("Create-With-Parameters")
     .WithCriteria(() => !BuildSystem.AppVeyor.IsRunningOnAppVeyor)
     .Does(() => {
         // excluding these tests from appveyor because they are causing timeout on their SQL
-        var masterConnectionString = @"data source=(LocalDb)\v12.0;";
+        var masterConnectionString = @"data source=(localdb)\MSSqlLocalDb;";
 
         var dbName = "CreateCakeTest";
         var mdfFilePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "MyCakeTest.mdf");
@@ -110,14 +110,14 @@ Task("Create-With-Parameters")
     .Finally(() =>
     {  
         // Cleanup
-        DropDatabase(@"data source=(LocalDb)\v12.0", "CreateCakeTest");
+        DropDatabase(@"data source=(localdb)\MSSqlLocalDb", "CreateCakeTest");
     });
 
 
 Task("SqlConnection")
     .Does(() => {
-        var masterConnectionString = @"data source=(LocalDb)\v12.0;";
-        var connectionString = @"data source=(LocalDb)\v12.0;Database=OpenConnection";
+        var masterConnectionString = @"data source=(localdb)\MSSqlLocalDb;";
+        var connectionString = @"data source=(localdb)\MSSqlLocalDb;Database=OpenConnection";
 
         var dbName = "OpenConnection";
 
@@ -134,14 +134,14 @@ Task("SqlConnection")
     .Finally(() =>
     {  
         // Cleanup
-        DropDatabase(@"data source=(LocalDb)\v12.0;", "OpenConnection");
+        DropDatabase(@"data source=(localdb)\MSSqlLocalDb;", "OpenConnection");
     });
 
 
 Task("SqlTimeout")
     .Does(() => {
         SetSqlCommandTimeout(3);
-        using (var connection = OpenSqlConnection(@"Data Source=(LocalDb)\v12.0;"))
+        using (var connection = OpenSqlConnection(@"Data Source=(localdb)\MSSqlLocalDb;"))
         {
             ExecuteSqlCommand(connection, "WAITFOR DELAY '00:00:02'");
         }
@@ -150,7 +150,7 @@ Task("SqlTimeout")
 
 Task("Restore-Database")
     .Does(() => {
-        var connString = @"data source=(LocalDb)\v12.0";
+        var connString = @"data source=(localdb)\MSSqlLocalDb";
 
         var backupFilePath = new FilePath(@".\src\Tests\multiFileBackup.bak");
         backupFilePath = backupFilePath.MakeAbsolute(Context.Environment);
@@ -166,13 +166,13 @@ Task("Restore-Database")
     .Finally(() =>
     {  
         // Cleanup
-        DropDatabase(@"data source=(LocalDb)\v12.0", "RestoredFromTest.Cake");
-        DropDatabase(@"data source=(LocalDb)\v12.0", "CakeRestoreTest");
+        DropDatabase(@"data source=(localdb)\MSSqlLocalDb", "RestoredFromTest.Cake");
+        DropDatabase(@"data source=(localdb)\MSSqlLocalDb", "CakeRestoreTest");
     });
 
 Task("Backup-Database")
     .Does(() => {
-		var connString = @"data source=(LocalDb)\v12.0";
+		var connString = @"data source=(localdb)\MSSqlLocalDb";
 		
         var backupFilePath = new FilePath(@".\src\Tests\multiFileBackup.bak");
         backupFilePath = backupFilePath.MakeAbsolute(Context.Environment);
@@ -189,13 +189,13 @@ Task("Backup-Database")
 	})
     .Finally(() =>
     {  
-        DropDatabase(@"data source=(LocalDb)\v12.0", "CakeRestoreTest");
+        DropDatabase(@"data source=(localdb)\MSSqlLocalDb", "CakeRestoreTest");
     });
 
 
 Task("Create-Bacpac")
     .Does(() =>{
-        var connString = @"data source=(LocalDb)\v12.0";
+        var connString = @"data source=(localdb)\MSSqlLocalDb";
 
         var dbName = "ForBacpac";
 
@@ -206,7 +206,7 @@ Task("Create-Bacpac")
     .Finally(() =>
     {  
         // Cleanup
-        DropDatabase(@"data source=(LocalDb)\v12.0", "ForBacpac");
+        DropDatabase(@"data source=(localdb)\MSSqlLocalDb", "ForBacpac");
         if(FileExists(@".\ForBacpac.bacpac"))
         {
             DeleteFile(@".\ForBacpac.bacpac");
@@ -216,7 +216,7 @@ Task("Create-Bacpac")
 
 Task("Restore-From-Bacpac")
     .Does(() =>{
-        var connString = @"data source=(LocalDb)\v12.0";
+        var connString = @"data source=(localdb)\MSSqlLocalDb";
 
         var dbName = "FromBacpac";
 
@@ -226,14 +226,14 @@ Task("Restore-From-Bacpac")
     .Finally(() =>
     {  
         // Cleanup
-        DropDatabase(@"data source=(LocalDb)\v12.0", "FromBacpac");
+        DropDatabase(@"data source=(localdb)\MSSqlLocalDb", "FromBacpac");
     });
 
 
 Task("Dacpac-Publish")
     .Does(() => 
     {
-        var connectionString = @"data source=(LocalDb)\v12.0";
+        var connectionString = @"data source=(localdb)\MSSqlLocalDb";
         var dbName = "DacpacTestDb";
         var dacpacFile = new FilePath(@".\src\Tests\Nsaga.dacpac");
 
@@ -244,7 +244,7 @@ Task("Dacpac-Publish")
     .Finally(() => 
     {
         // Cleanup
-        DropDatabase(@"data source=(LocalDb)\v12.0", "DacpacTestDb");
+        DropDatabase(@"data source=(localdb)\MSSqlLocalDb", "DacpacTestDb");
     });
 
 
@@ -252,7 +252,7 @@ Task("Dacpac-Extract")
     .Does(() => 
     {
         var dbName = "DacpacTestDb";
-        var connectionString = @"data source=(LocalDb)\v12.0";
+        var connectionString = @"data source=(localdb)\MSSqlLocalDb";
         var resultingFilePath = "NsagaCreated.dacpac";
         var settings = new ExtractDacpacSettings("TestApp", "1.0.0.0") { OutputFile = resultingFilePath };
 
@@ -268,7 +268,7 @@ Task("Dacpac-Extract")
     })
     .Finally(() => 
     {
-        DropDatabase(@"data source=(LocalDb)\v12.0", "DacpacTestDb");
+        DropDatabase(@"data source=(localdb)\MSSqlLocalDb", "DacpacTestDb");
         //if(FileExists(@".\NsagaCreated.dacpac"))
         {
             DeleteFile(@".\NsagaCreated.dacpac");


### PR DESCRIPTION
Update to Cake 0.33
Also updated all the rest of the packages (mostly in testing project)
And changed all the tests/samples to refer to `(localdb)\MSSqlLocalDB` instead of `v12.0`.