### PR TITLE
Add support for switching to restricted mode

### DIFF
--- a/src/Cake.SqlServer/Backup/RestoreSqlBackupSettings.cs
+++ b/src/Cake.SqlServer/Backup/RestoreSqlBackupSettings.cs
@@ -56,13 +56,6 @@ namespace Cake.SqlServer
         public DbUserMode SwitchToUserMode { get; set; } = DbUserMode.SingleUser;
 
         /// <summary>
-        /// Before restoring backup, database will be switched to a single user mode. 
-        /// Default operation is to go into single user mode. However in some situation this might not work.
-        /// Use this switch to bypass single user mode and restore the DB as it is
-        /// </summary>
-        public bool SwitchToRestrictedUserMode { get; set; }
-
-        /// <summary>
         /// If set this specifies which BackupSet should be used when restoring the main backup files.
         /// </summary>
         public int? BackupSetFile { get; set; }
@@ -71,14 +64,24 @@ namespace Cake.SqlServer
         /// If set this specifies which BackupSet should be used when restoring the differential backup files.
         /// </summary>
         public int? DifferentialBackupSetFile { get; set; }
-
-        
     }
 
+    /// <summary>
+    /// This enum specifies what user mode the database should be in
+    /// </summary>
     public enum DbUserMode
     {
+        /// <summary>
+        /// This is the default database user access mode. In this database user access mode any user who have permission to access the database can access the database.
+        /// </summary>
         MultiUser,
+        /// <summary>
+        /// In this user mode at any given point of time only one user can access the database. The user can be any user who has access to the database.
+        /// </summary>
         SingleUser,
+        /// <summary>
+        /// In this user mode only the users who have db_owner or db_creator permission can access.
+        /// </summary>
         RestrictedUser
     }
 }

--- a/src/Cake.SqlServer/Backup/RestoreSqlBackupSettings.cs
+++ b/src/Cake.SqlServer/Backup/RestoreSqlBackupSettings.cs
@@ -9,14 +9,6 @@ namespace Cake.SqlServer
     public class RestoreSqlBackupSettings
     {
         /// <summary>
-        /// Default constructor for settings object. Sets SwitchToSingleUserMode to true.
-        /// </summary>
-        public RestoreSqlBackupSettings()
-        {
-            SwitchToSingleUserMode = true;
-        }
-
-        /// <summary>
         /// Gets or sets the new name of the database.
         /// Name of the database where to restore. If this is not specified, database name is taken from the backup file
         /// </summary>
@@ -46,8 +38,29 @@ namespace Cake.SqlServer
         /// Before restoring backup, database will be switched to a single user mode. 
         /// Default operation is to go into single user mode. However in some situation this might not work.
         /// Use this switch to bypass single user mode and restore the DB as it is
+        /// 
+        /// This property has been obsoleted by SwitchToUserMode which allows for a third option
         /// </summary>
-        public bool SwitchToSingleUserMode { get; set; }
+        [Obsolete("Use SwitchToUserMode instead")]
+        public bool SwitchToSingleUserMode
+        {
+            get => SwitchToUserMode == DbUserMode.SingleUser;
+            set => SwitchToUserMode = value ? DbUserMode.SingleUser : DbUserMode.MultiUser;
+        }
+
+        /// <summary>
+        /// Before restoring backup, database will be switched to the user mode selected
+        /// Default operation is to go into single user mode. However in some situation this might not work.
+        /// Use this switch to bypass single user mode and restore the DB as it is, or your can use restricted mode instead.
+        /// </summary>
+        public DbUserMode SwitchToUserMode { get; set; } = DbUserMode.SingleUser;
+
+        /// <summary>
+        /// Before restoring backup, database will be switched to a single user mode. 
+        /// Default operation is to go into single user mode. However in some situation this might not work.
+        /// Use this switch to bypass single user mode and restore the DB as it is
+        /// </summary>
+        public bool SwitchToRestrictedUserMode { get; set; }
 
         /// <summary>
         /// If set this specifies which BackupSet should be used when restoring the main backup files.
@@ -59,5 +72,13 @@ namespace Cake.SqlServer
         /// </summary>
         public int? DifferentialBackupSetFile { get; set; }
 
+        
+    }
+
+    public enum DbUserMode
+    {
+        MultiUser,
+        SingleUser,
+        RestrictedUser
     }
 }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.33.0" />
+    <package id="Cake" version="0.35.0" />
 </packages>


### PR DESCRIPTION
When I try and restore I have enough users fighting for connections that I often lose the race and end up locked out of my db with single user mode on, but I'm not the one!  This patch makes it possible to use restricted mode instead.