### PR TITLE
Fix default value for PopulateFilesOnFileGroups

### DIFF
--- a/src/Cake.SqlServer/Dac/PublishDacpacSettings.cs
+++ b/src/Cake.SqlServer/Dac/PublishDacpacSettings.cs
@@ -687,7 +687,7 @@ namespace Cake.SqlServer
         /// True to specify files for filegroups; otherwise false.
         /// Default is true.
         /// </value>
-        public bool PopulateFilesOnFileGroups { get; set; }
+        public bool PopulateFilesOnFileGroups { get; set; } = true;
 
         /// <summary>
         /// Get or set boolean that specifies whether the database will be registered as a Data-Tier Application.


### PR DESCRIPTION
The documentation states that the default value for the PopulateFilesOnFileGroups property is true.